### PR TITLE
Fixed issue #2 : cloud covering up title text

### DIFF
--- a/index.css
+++ b/index.css
@@ -270,6 +270,7 @@ footer{
         left: 20vw;
         position: absolute;
         /* background-image: url(https://web.archive.org/web/20180901170713im_/http:/seanhalpin.io/assets/img/ui/cloud.svg); */
+        z-index: -100;
     }
     .cloud2{
         /* width: 30vw; */
@@ -277,7 +278,8 @@ footer{
         left: 66vw;
         position: absolute;
         /* background-image: url(https://web.archive.org/web/20180901170713im_/http:/seanhalpin.io/assets/img/ui/cloud.svg); */
-    }
+        z-index: -100;
+      }
     .nav{
         width: 99.0vw;
     }


### PR DESCRIPTION
Fixed issue #2 

- Cloud was covering up the text and images when the device width was small , as on mobile phones
- Changed the CSS of the `div` containing the clouds with a negative z-index to push it behind other items.

## Following is the screenshot of resolved bug

![Screenshot_20230205_195151](https://user-images.githubusercontent.com/11803841/216825209-bb4fbb1f-ceec-4c87-bced-f40552a672fa.png)
